### PR TITLE
Feature/response object

### DIFF
--- a/toop-edm/src/main/java/eu/toop/edm/EDMResponse.java
+++ b/toop-edm/src/main/java/eu/toop/edm/EDMResponse.java
@@ -15,44 +15,24 @@
  */
 package eu.toop.edm;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.xml.datatype.XMLGregorianCalendar;
-
-import eu.toop.edm.model.*;
-import eu.toop.regrep.rim.*;
-import org.w3c.dom.Node;
-
 import com.helger.commons.ValueEnforcer;
 import com.helger.commons.annotation.Nonempty;
 import com.helger.commons.annotation.ReturnsMutableCopy;
 import com.helger.commons.annotation.ReturnsMutableObject;
-import com.helger.commons.collection.CollectionHelper;
-import com.helger.commons.collection.impl.CommonsArrayList;
-import com.helger.commons.collection.impl.CommonsLinkedHashMap;
-import com.helger.commons.collection.impl.CommonsLinkedHashSet;
-import com.helger.commons.collection.impl.ICommonsList;
-import com.helger.commons.collection.impl.ICommonsOrderedMap;
-import com.helger.commons.collection.impl.ICommonsOrderedSet;
+import com.helger.commons.collection.impl.*;
 import com.helger.commons.datetime.PDTFactory;
 import com.helger.commons.equals.EqualsHelper;
 import com.helger.commons.hashcode.HashCodeGenerator;
 import com.helger.commons.string.StringHelper;
 import com.helger.commons.string.ToStringGenerator;
 import com.helger.datetime.util.PDTXMLConverter;
-
 import eu.toop.edm.jaxb.cccev.CCCEVConceptType;
 import eu.toop.edm.jaxb.cv.agent.AgentType;
-import eu.toop.edm.jaxb.dcatap.DCatAPDatasetType;
-import eu.toop.edm.slot.SlotConceptValues;
+import eu.toop.edm.model.AgentPojo;
+import eu.toop.edm.model.ConceptPojo;
+import eu.toop.edm.model.EQueryDefinitionType;
+import eu.toop.edm.model.ResponseObjectPojo;
 import eu.toop.edm.slot.SlotDataProvider;
-import eu.toop.edm.slot.SlotDocumentMetadata;
 import eu.toop.edm.slot.SlotIssueDateTime;
 import eu.toop.edm.slot.SlotSpecificationIdentifier;
 import eu.toop.edm.xml.IJAXBVersatileReader;
@@ -61,14 +41,22 @@ import eu.toop.edm.xml.JAXBVersatileReader;
 import eu.toop.edm.xml.JAXBVersatileWriter;
 import eu.toop.edm.xml.cagv.AgentMarshaller;
 import eu.toop.edm.xml.cccev.CCCEV;
-import eu.toop.edm.xml.cccev.ConceptMarshaller;
-import eu.toop.edm.xml.dcatap.DatasetMarshaller;
 import eu.toop.regrep.ERegRepResponseStatus;
 import eu.toop.regrep.RegRep4Reader;
 import eu.toop.regrep.RegRep4Writer;
 import eu.toop.regrep.RegRepHelper;
 import eu.toop.regrep.query.QueryResponse;
+import eu.toop.regrep.rim.*;
 import eu.toop.regrep.slot.ISlotProvider;
+import org.w3c.dom.Node;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * This class contains the data model for a single TOOP EDM Request. It requires
@@ -200,6 +188,10 @@ public class EDMResponse
     return m_aResponseObjects.getClone ();
   }
 
+  /**
+   * @deprecated Since beta3; Use {@link #responseObjects()} or {@link #getAllResponseObjects()}
+   * and get the concepts through the {@link ResponseObjectPojo} ()} instead
+   */
   @Nonnull
   @Deprecated
   @ReturnsMutableObject
@@ -208,6 +200,10 @@ public class EDMResponse
     return m_aResponseObjects.isNotEmpty() ? m_aResponseObjects.get(0).concepts() : new CommonsArrayList<>();
   }
 
+  /**
+   * @deprecated Since beta3; Use {@link #responseObjects()} or {@link #getAllResponseObjects()}
+   * and get the concepts through the {@link ResponseObjectPojo} ()} instead
+   */
   @Nonnull
   @Deprecated
   @ReturnsMutableCopy
@@ -449,7 +445,10 @@ public class EDMResponse
       return dataProvider (a == null ? null : AgentPojo.builder (a));
     }
 
-
+    /**
+     * @deprecated Since beta3; Create a {@link ResponseObjectPojo} ()} using
+     * {@link #responseObject(ResponseObjectPojo.Builder)} and put the concepts there instead
+     */
     @Nonnull
     @Deprecated
     public Builder addConcept (@Nullable final CCCEVConceptType a)
@@ -457,6 +456,10 @@ public class EDMResponse
       return addConcept (a == null ? null : ConceptPojo.builder (a));
     }
 
+    /**
+     * @deprecated Since beta3; Create a {@link ResponseObjectPojo} ()} using
+     * {@link #responseObject(ResponseObjectPojo.Builder)} and put the concepts there instead
+     */
     @Nonnull
     @Deprecated
     public Builder addConcept (@Nullable final ConceptPojo.Builder a)
@@ -464,6 +467,10 @@ public class EDMResponse
       return addConcept (a == null ? null : a.build ());
     }
 
+    /**
+     * @deprecated Since beta3; Create a {@link ResponseObjectPojo} ()} using
+     * {@link #responseObject(ResponseObjectPojo.Builder)} and put the concepts there instead
+     */
     @Nonnull
     @Deprecated
     public Builder addConcept (@Nullable final ConceptPojo a)
@@ -473,6 +480,10 @@ public class EDMResponse
       return this;
     }
 
+    /**
+     * @deprecated Since beta3; Create a {@link ResponseObjectPojo} ()} using
+     * {@link #responseObject(ResponseObjectPojo.Builder)} and put the concepts there instead
+     */
     @Nonnull
     @Deprecated
     public Builder concept (@Nullable final CCCEVConceptType a)
@@ -480,6 +491,10 @@ public class EDMResponse
       return concept (a == null ? null : ConceptPojo.builder (a));
     }
 
+    /**
+     * @deprecated Since beta3; Create a {@link ResponseObjectPojo} ()} using
+     * {@link #responseObject(ResponseObjectPojo.Builder)} and put the concepts there instead
+     */
     @Nonnull
     @Deprecated
     public Builder concept (@Nullable final ConceptPojo.Builder a)
@@ -487,6 +502,10 @@ public class EDMResponse
       return concept (a == null ? null : a.build ());
     }
 
+    /**
+     * @deprecated Since beta3; Create a {@link ResponseObjectPojo} ()} using
+     * {@link #responseObject(ResponseObjectPojo.Builder)} and put the concepts there instead
+     */
     @Nonnull
     @Deprecated
     public Builder concept (@Nullable final ConceptPojo a)
@@ -498,6 +517,10 @@ public class EDMResponse
       return this;
     }
 
+    /**
+     * @deprecated Since beta3; Create a {@link ResponseObjectPojo} ()} using
+     * {@link #responseObject(ResponseObjectPojo.Builder)} and put the concepts there instead
+     */
     @Nonnull
     @Deprecated
     public Builder concepts (@Nullable final ConceptPojo... a)
@@ -506,6 +529,10 @@ public class EDMResponse
       return this;
     }
 
+    /**
+     * @deprecated Since beta3; Create a {@link ResponseObjectPojo} ()} using
+     * {@link #responseObject(ResponseObjectPojo.Builder)} and put the concepts there instead
+     */
     @Nonnull
     @Deprecated
     public Builder concepts (@Nullable final Iterable <ConceptPojo> a)
@@ -513,7 +540,6 @@ public class EDMResponse
       m_aConcepts.setAll (a);
       return this;
     }
-
 
     @Nonnull
     public Builder addResponseObject (@Nullable final RegistryObjectType a)

--- a/toop-edm/src/main/java/eu/toop/edm/EDMResponse.java
+++ b/toop-edm/src/main/java/eu/toop/edm/EDMResponse.java
@@ -201,6 +201,22 @@ public class EDMResponse
   }
 
   @Nonnull
+  @Deprecated
+  @ReturnsMutableObject
+  public final List<ConceptPojo> concepts ()
+  {
+    return m_aResponseObjects.isNotEmpty() ? m_aResponseObjects.get(0).concepts() : new CommonsArrayList<>();
+  }
+
+  @Nonnull
+  @Deprecated
+  @ReturnsMutableCopy
+  public final List <ConceptPojo> getAllConcepts ()
+  {
+    return m_aResponseObjects.isNotEmpty() ? m_aResponseObjects.get(0).getAllConcepts() : new CommonsArrayList<>();
+  }
+
+  @Nonnull
   private QueryResponse _createQueryResponse (@Nonnull final ICommonsList <ISlotProvider> aProviders)
   {
     final ICommonsOrderedMap <String, ISlotProvider> aProviderMap = new CommonsLinkedHashMap <> ();
@@ -361,6 +377,8 @@ public class EDMResponse
     private LocalDateTime m_aIssueDateTime;
     private AgentPojo m_aDataProvider;
     private final ICommonsList <ResponseObjectPojo> m_aResponseObjects = new CommonsArrayList <> ();
+    // To support deprecated method calls
+    private final ICommonsList <ConceptPojo> m_aConcepts = new CommonsArrayList <> ();
 
     protected Builder ()
     {}
@@ -430,6 +448,72 @@ public class EDMResponse
     {
       return dataProvider (a == null ? null : AgentPojo.builder (a));
     }
+
+
+    @Nonnull
+    @Deprecated
+    public Builder addConcept (@Nullable final CCCEVConceptType a)
+    {
+      return addConcept (a == null ? null : ConceptPojo.builder (a));
+    }
+
+    @Nonnull
+    @Deprecated
+    public Builder addConcept (@Nullable final ConceptPojo.Builder a)
+    {
+      return addConcept (a == null ? null : a.build ());
+    }
+
+    @Nonnull
+    @Deprecated
+    public Builder addConcept (@Nullable final ConceptPojo a)
+    {
+      if (a != null)
+        m_aConcepts.add (a);
+      return this;
+    }
+
+    @Nonnull
+    @Deprecated
+    public Builder concept (@Nullable final CCCEVConceptType a)
+    {
+      return concept (a == null ? null : ConceptPojo.builder (a));
+    }
+
+    @Nonnull
+    @Deprecated
+    public Builder concept (@Nullable final ConceptPojo.Builder a)
+    {
+      return concept (a == null ? null : a.build ());
+    }
+
+    @Nonnull
+    @Deprecated
+    public Builder concept (@Nullable final ConceptPojo a)
+    {
+      if (a != null)
+        m_aConcepts.set (a);
+      else
+        m_aConcepts.clear ();
+      return this;
+    }
+
+    @Nonnull
+    @Deprecated
+    public Builder concepts (@Nullable final ConceptPojo... a)
+    {
+      m_aConcepts.setAll (a);
+      return this;
+    }
+
+    @Nonnull
+    @Deprecated
+    public Builder concepts (@Nullable final Iterable <ConceptPojo> a)
+    {
+      m_aConcepts.setAll (a);
+      return this;
+    }
+
 
     @Nonnull
     public Builder addResponseObject (@Nullable final RegistryObjectType a)
@@ -551,6 +635,10 @@ public class EDMResponse
     @Nonnull
     public EDMResponse build ()
     {
+      // Support old (deprecated) method of adding concepts
+      if(m_aConcepts.isNotEmpty())
+        m_aResponseObjects.add (ResponseObjectPojo.builder().randomID().concepts(m_aConcepts).build());
+
       checkConsistency ();
 
       return new EDMResponse (m_eQueryDefinition,

--- a/toop-edm/src/main/java/eu/toop/edm/model/ResponseObjectPojo.java
+++ b/toop-edm/src/main/java/eu/toop/edm/model/ResponseObjectPojo.java
@@ -1,0 +1,398 @@
+package eu.toop.edm.model;
+
+import com.helger.commons.ValueEnforcer;
+import com.helger.commons.annotation.Nonempty;
+import com.helger.commons.annotation.ReturnsMutableCopy;
+import com.helger.commons.annotation.ReturnsMutableObject;
+import com.helger.commons.collection.CollectionHelper;
+import com.helger.commons.collection.impl.CommonsArrayList;
+import com.helger.commons.collection.impl.ICommonsList;
+import com.helger.commons.equals.EqualsHelper;
+import com.helger.commons.hashcode.HashCodeGenerator;
+import com.helger.commons.string.StringHelper;
+import com.helger.commons.string.ToStringGenerator;
+import com.helger.datetime.util.PDTXMLConverter;
+import eu.toop.edm.EDMResponse;
+import eu.toop.edm.jaxb.cccev.CCCEVConceptType;
+import eu.toop.edm.jaxb.dcatap.DCatAPDatasetType;
+import eu.toop.edm.slot.*;
+import eu.toop.edm.xml.cagv.AgentMarshaller;
+import eu.toop.edm.xml.cccev.ConceptMarshaller;
+import eu.toop.edm.xml.dcatap.DatasetMarshaller;
+import eu.toop.regrep.rim.*;
+import eu.toop.regrep.slot.ISlotProvider;
+import org.w3c.dom.Node;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class ResponseObjectPojo {
+    private final String m_sID;
+    private final ICommonsList<ConceptPojo> m_aConcepts = new CommonsArrayList<>();
+    private final DatasetPojo m_aDataset;
+    private final RepositoryItemRefPojo m_aRepositoryItemRef;
+
+    public ResponseObjectPojo(@Nonnull @Nonempty final String sID,
+                              @Nullable final ICommonsList <ConceptPojo> aConcepts,
+                              @Nullable final DatasetPojo aDataset,
+                              @Nullable final RepositoryItemRefPojo aRepositoryItemRef) {
+        ValueEnforcer.notEmpty (sID, "RequestID");
+        final int nConcepts = CollectionHelper.getSize (aConcepts);
+        ValueEnforcer.isFalse ((nConcepts == 0 && aDataset == null) || (nConcepts != 0 && aDataset != null),
+                "Exactly one of Concept and Dataset must be set");
+
+        m_sID = sID;
+        if (aConcepts != null)
+            m_aConcepts.addAll(aConcepts);
+        m_aDataset = aDataset;
+        m_aRepositoryItemRef = aRepositoryItemRef;
+    }
+
+    @Nonnull
+    @ReturnsMutableObject
+    public final List<ConceptPojo> concepts ()
+    {
+        return m_aConcepts;
+    }
+
+    @Nonnull
+    @ReturnsMutableCopy
+    public final List <ConceptPojo> getAllConcepts ()
+    {
+        return m_aConcepts.getClone ();
+    }
+
+    @Nullable
+    public final DatasetPojo getDataset ()
+    {
+        return m_aDataset;
+    }
+
+    @Nullable
+    public final RepositoryItemRefPojo getRepositoryItemRef ()
+    {
+        return m_aRepositoryItemRef;
+    }
+
+    @Nonnull
+    public RegistryObjectType getAsRegistryObject()
+    {
+        final ICommonsList <ISlotProvider> aSlots = new CommonsArrayList <> ();
+
+        final ExtrinsicObjectType ret = new ExtrinsicObjectType();
+
+        if(StringHelper.hasText(m_sID))
+            ret.setId(m_sID);
+
+        // ConceptValues
+        if (m_aConcepts.isNotEmpty ())
+            aSlots.add (new SlotConceptValues (m_aConcepts));
+
+        // DocumentMetadata
+        if (m_aDataset != null)
+            aSlots.add (new SlotDocumentMetadata (m_aDataset));
+
+        // All slots inside of RegistryObject
+        for (final ISlotProvider aSlot : aSlots)
+            ret.addSlot (aSlot.createSlot ());
+
+        if (m_aRepositoryItemRef != null)
+            ret.setRepositoryItemRef(m_aRepositoryItemRef.getAsSimpleLink());
+
+        return ret;
+    }
+
+    @Nonnull
+    public ObjectRefType getAsObjectRef()
+    {
+        if (m_aRepositoryItemRef != null)
+            throw new IllegalStateException("ObjectRef may NOT contain a RepositoryItemRef.");
+
+        final ICommonsList <ISlotProvider> aSlots = new CommonsArrayList <> ();
+
+        final ObjectRefType ret = new ObjectRefType();
+
+        if(StringHelper.hasText(m_sID))
+            ret.setId(m_sID);
+
+        // ConceptValues
+        if (m_aConcepts.isNotEmpty ())
+            aSlots.add (new SlotConceptValues (m_aConcepts));
+
+        // DocumentMetadata
+        if (m_aDataset != null)
+            aSlots.add (new SlotDocumentMetadata (m_aDataset));
+
+        // All slots inside of RegistryObject
+        for (final ISlotProvider aSlot : aSlots)
+            ret.addSlot (aSlot.createSlot ());
+
+        return ret;
+    }
+
+
+    @Override
+    public boolean equals (final Object o)
+    {
+        if (o == this)
+            return true;
+        if (o == null || !getClass ().equals (o.getClass ()))
+            return false;
+        final ResponseObjectPojo rhs = (ResponseObjectPojo) o;
+        return EqualsHelper.equals (m_sID, rhs.m_sID) &&
+                EqualsHelper.equals (m_aConcepts, rhs.m_aConcepts) &&
+                EqualsHelper.equals (m_aDataset, rhs.m_aDataset) &&
+                EqualsHelper.equals (m_aRepositoryItemRef, rhs.m_aRepositoryItemRef);
+    }
+
+    @Override
+    public int hashCode ()
+    {
+        return new HashCodeGenerator(this).append (m_sID)
+                .append (m_sID)
+                .append (m_aConcepts)
+                .append (m_aDataset)
+                .append (m_aRepositoryItemRef)
+                .getHashCode ();
+    }
+
+    @Override
+    public String toString ()
+    {
+        return new ToStringGenerator(this).append ("ID", m_sID)
+                .append ("IDSchemeID", m_sID)
+                .append ("FamilyName", m_aConcepts)
+                .append ("GivenName", m_aDataset)
+                .append ("GenderCode", m_aRepositoryItemRef)
+                .getToString ();
+    }
+
+
+    @Nonnull
+    public static Builder builder ()
+    {
+        return new Builder();
+    }
+
+    @Nonnull
+    public static Builder builder (@Nullable final RegistryObjectType a)
+    {
+        final Builder ret = new Builder();
+        if (a != null)
+        {
+            if((a.getId() != null) && (StringHelper.hasText(a.getId())))
+                ret.id(a.getId());
+            for (final SlotType aSlot : a.getSlot())
+                _applySlots(aSlot, ret);
+
+            if (a instanceof ExtrinsicObjectType) {
+                final ExtrinsicObjectType aEO = (ExtrinsicObjectType) a;
+
+                if (aEO.getRepositoryItemRef() != null)
+                    ret.repositoryItemRef(aEO.getRepositoryItemRef());
+            }
+        }
+        return ret;
+    }
+
+    @Nonnull
+    public static Builder builder (@Nullable final ObjectRefType a)
+    {
+        final Builder ret = new Builder();
+        if (a != null)
+        {
+            if((a.getId() != null) && (!a.getId().isEmpty()))
+                ret.id(a.getId());
+            for (final SlotType aSlot : a.getSlot())
+                _applySlots(aSlot, ret);
+        }
+        return ret;
+    }
+
+    public static class Builder
+    {
+        private String m_sID;
+        private final ICommonsList <ConceptPojo> m_aConcepts = new CommonsArrayList <> ();
+        private DatasetPojo m_aDataset;
+        private RepositoryItemRefPojo m_aRepositoryItemRef;
+
+        protected Builder ()
+        {}
+
+        @Nonnull
+        public Builder id (@Nullable final UUID a)
+        {
+            return id (a == null ? null : a.toString ());
+        }
+
+        @Nonnull
+        public Builder id (@Nullable final String s)
+        {
+            m_sID = s;
+            return this;
+        }
+
+        @Nonnull
+        public Builder randomID ()
+        {
+            m_sID = UUID.randomUUID().toString();
+            return this;
+        }
+
+
+        @Nonnull
+        public Builder addConcept (@Nullable final CCCEVConceptType a)
+        {
+            return addConcept (a == null ? null : ConceptPojo.builder (a));
+        }
+
+        @Nonnull
+        public Builder addConcept (@Nullable final ConceptPojo.Builder a)
+        {
+            return addConcept (a == null ? null : a.build ());
+        }
+
+        @Nonnull
+        public Builder addConcept (@Nullable final ConceptPojo a)
+        {
+            if (a != null)
+                m_aConcepts.add (a);
+            return this;
+        }
+
+        @Nonnull
+        public Builder concept (@Nullable final CCCEVConceptType a)
+        {
+            return concept (a == null ? null : ConceptPojo.builder (a));
+        }
+
+        @Nonnull
+        public Builder concept (@Nullable final ConceptPojo.Builder a)
+        {
+            return concept (a == null ? null : a.build ());
+        }
+
+        @Nonnull
+        public Builder concept (@Nullable final ConceptPojo a)
+        {
+            if (a != null)
+                m_aConcepts.set (a);
+            else
+                m_aConcepts.clear ();
+            return this;
+        }
+
+        @Nonnull
+        public Builder concepts (@Nullable final ConceptPojo... a)
+        {
+            m_aConcepts.setAll (a);
+            return this;
+        }
+
+        @Nonnull
+        public Builder concepts (@Nullable final Iterable <ConceptPojo> a)
+        {
+            m_aConcepts.setAll (a);
+            return this;
+        }
+
+        @Nonnull
+        public Builder dataset (@Nullable final DatasetPojo.Builder a)
+        {
+            return dataset (a == null ? null : a.build ());
+        }
+
+        @Nonnull
+        public Builder dataset (@Nullable final DatasetPojo a)
+        {
+            m_aDataset = a;
+            return this;
+        }
+
+        @Nonnull
+        public Builder dataset (@Nullable final DCatAPDatasetType a)
+        {
+            return dataset (a == null ? null : DatasetPojo.builder (a));
+        }
+
+        @Nonnull
+        public Builder repositoryItemRef (@Nullable final RepositoryItemRefPojo.Builder a)
+        {
+            return repositoryItemRef (a == null ? null : a.build ());
+        }
+
+        @Nonnull
+        public Builder repositoryItemRef (@Nullable final RepositoryItemRefPojo a)
+        {
+            m_aRepositoryItemRef = a;
+            return this;
+        }
+
+        @Nonnull
+        public Builder repositoryItemRef (@Nullable final SimpleLinkType a)
+        {
+            return repositoryItemRef (a == null ? null : RepositoryItemRefPojo.builder (a));
+        }
+
+        public void checkConsistency ()
+        {
+            if (StringHelper.hasNoText (m_sID))
+                throw new IllegalStateException ("ID must be present");
+            final int nConcepts = CollectionHelper.getSize (m_aConcepts);
+            if((nConcepts == 0 && m_aDataset == null) || (nConcepts != 0 && m_aDataset != null))
+                throw new IllegalStateException("Exactly one of Concept and Dataset must be set");
+
+        }
+
+        @Nonnull
+        public ResponseObjectPojo build ()
+        {
+            checkConsistency ();
+
+            return new ResponseObjectPojo (m_sID,
+                                           m_aConcepts,
+                                           m_aDataset,
+                                           m_aRepositoryItemRef);
+        }
+    }
+
+    private static void _applySlots (@Nonnull final SlotType aSlot, @Nonnull final Builder aBuilder)
+    {
+        final String sName = aSlot.getName ();
+        final ValueType aSlotValue = aSlot.getSlotValue ();
+        switch (sName)
+        {
+            case SlotConceptValues.NAME:
+                if (aSlotValue instanceof CollectionValueType)
+                {
+                    final List <ValueType> aElements = ((CollectionValueType) aSlotValue).getElement ();
+                    if (!aElements.isEmpty ())
+                    {
+                        for (final ValueType aElement : aElements)
+                            if (aElement instanceof AnyValueType)
+                            {
+                                final Object aElementValue = ((AnyValueType) aElement).getAny ();
+                                if (aElementValue instanceof Node)
+                                    aBuilder.addConcept (new ConceptMarshaller().read ((Node) aElementValue));
+                            }
+                    }
+                }
+                break;
+            case SlotDocumentMetadata.NAME:
+            {
+                if (aSlotValue instanceof AnyValueType)
+                {
+                    final Node aAny = (Node) ((AnyValueType) aSlotValue).getAny ();
+                    aBuilder.dataset (DatasetPojo.builder (new DatasetMarshaller().read (aAny)));
+                }
+                break;
+            }
+            default:
+                throw new IllegalStateException ("Slot is not defined: " + sName);
+        }
+    }
+}

--- a/toop-edm/src/main/java/eu/toop/edm/model/ResponseObjectPojo.java
+++ b/toop-edm/src/main/java/eu/toop/edm/model/ResponseObjectPojo.java
@@ -26,12 +26,10 @@ import com.helger.commons.equals.EqualsHelper;
 import com.helger.commons.hashcode.HashCodeGenerator;
 import com.helger.commons.string.StringHelper;
 import com.helger.commons.string.ToStringGenerator;
-import com.helger.datetime.util.PDTXMLConverter;
-import eu.toop.edm.EDMResponse;
 import eu.toop.edm.jaxb.cccev.CCCEVConceptType;
 import eu.toop.edm.jaxb.dcatap.DCatAPDatasetType;
-import eu.toop.edm.slot.*;
-import eu.toop.edm.xml.cagv.AgentMarshaller;
+import eu.toop.edm.slot.SlotConceptValues;
+import eu.toop.edm.slot.SlotDocumentMetadata;
 import eu.toop.edm.xml.cccev.ConceptMarshaller;
 import eu.toop.edm.xml.dcatap.DatasetMarshaller;
 import eu.toop.regrep.rim.*;
@@ -40,9 +38,7 @@ import org.w3c.dom.Node;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.xml.datatype.XMLGregorianCalendar;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 public class ResponseObjectPojo {

--- a/toop-edm/src/main/java/eu/toop/edm/model/ResponseObjectPojo.java
+++ b/toop-edm/src/main/java/eu/toop/edm/model/ResponseObjectPojo.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018-2020 toop.eu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.toop.edm.model;
 
 import com.helger.commons.ValueEnforcer;

--- a/toop-edm/src/main/resources/200/TOOP_BUSINESS_RULES.xslt
+++ b/toop-edm/src/main/resources/200/TOOP_BUSINESS_RULES.xslt
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Copyright (C) 2018-2020 toop.eu
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <xsl:stylesheet xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:cagv="https://semic.org/sa/cv/cagv/agent-2.0.0#" xmlns:cbc="https://semic.org/sa/cv/common/cbc-2.0.0#" xmlns:cbd="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cccev="https://semic.org/sa/cv/cccev-2.0.0#" xmlns:cpov="http://www.w3.org/ns/corevocabulary/po" xmlns:cva="http://www.w3.org/ns/corevocabulary/AggregateComponents" xmlns:cvb="http://www.w3.org/ns/corevocabulary/BasicComponents" xmlns:dcat="http://data.europa.eu/r5r/" xmlns:dct="http://purl.org/dc/terms/" xmlns:iso="http://purl.oclc.org/dsdl/schematron" xmlns:locn="http://www.w3.org/ns/locn#" xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:4.0" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:4.0" xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:4.0" xmlns:saxon="http://saxon.sf.net/" xmlns:schold="http://www.ascc.net/xml/schematron" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="urn:oasis:names:tc:ebxml-regrep:xsd:query:4.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
 <!--Implementers: please note that overriding process-prolog or process-root is 
     the preferred method for meta-stylesheets to use where possible. -->

--- a/toop-edm/src/main/resources/200/TOOP_EDM.xslt
+++ b/toop-edm/src/main/resources/200/TOOP_EDM.xslt
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Copyright (C) 2018-2020 toop.eu
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <xsl:stylesheet xmlns:svrl="http://purl.oclc.org/dsdl/svrl" xmlns:cagv="https://semic.org/sa/cv/cagv/agent-2.0.0#" xmlns:cbc="https://semic.org/sa/cv/common/cbc-2.0.0#" xmlns:cbd="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cccev="https://semic.org/sa/cv/cccev-2.0.0#" xmlns:cpov="http://www.w3.org/ns/corevocabulary/po" xmlns:cva="http://www.w3.org/ns/corevocabulary/AggregateComponents" xmlns:cvb="http://www.w3.org/ns/corevocabulary/BasicComponents" xmlns:dcat="http://data.europa.eu/r5r/" xmlns:dct="http://purl.org/dc/terms/" xmlns:iso="http://purl.oclc.org/dsdl/schematron" xmlns:locn="http://www.w3.org/ns/locn#" xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:4.0" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:4.0" xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:4.0" xmlns:saxon="http://saxon.sf.net/" xmlns:schold="http://www.ascc.net/xml/schematron" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="urn:oasis:names:tc:ebxml-regrep:xsd:query:4.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
 <!--Implementers: please note that overriding process-prolog or process-root is 
     the preferred method for meta-stylesheets to use where possible. -->

--- a/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
+++ b/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
@@ -27,6 +27,8 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 
 import eu.toop.edm.model.*;
+import eu.toop.edm.xml.cccev.CCCEV;
+import eu.toop.regrep.RegRep4Reader;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
@@ -54,10 +56,11 @@ public final class EDMResponseTest
     // Write
     final byte [] aBytes = aResp.getWriter ().getAsBytes ();
     assertNotNull (aBytes);
+    System.out.println(aResp.getWriter().getAsString());
 
     // Re-read
-    final EDMResponse aResp2 = EDMResponse.reader ().read (aBytes);
-
+//    final EDMResponse aResp2 = EDMResponse.reader ().read (aBytes);
+    final EDMResponse aResp2 = EDMResponse.create(RegRep4Reader.queryResponse(CCCEV.XSDS).read(aBytes));
     // Compare with original
     assertEquals (aResp, aResp2);
     CommonsTestHelper.testDefaultImplementationWithEqualContentObject (aResp, aResp2);
@@ -119,6 +122,29 @@ public final class EDMResponseTest
   }
 
   @Nonnull
+  private static EDMResponse.Builder _respConceptDeprecated ()
+  {
+    return _resp ().queryDefinition (EQueryDefinitionType.CONCEPT)
+                    .concept(ConceptPojo.builder ()
+                            .id ("ConceptID-1")
+                            .name (EToopConcept.REGISTERED_ORGANIZATION)
+                            .addChild (ConceptPojo.builder ()
+                                    .randomID ()
+                                    .name (EToopConcept.COMPANY_NAME)
+                                    .valueText ("Helger Enterprises"))
+                            .addChild (ConceptPojo.builder ()
+                                    .randomID ()
+                                    .name (EToopConcept.FAX_NUMBER)
+                                    .valueText ("342342424"))
+                            .addChild (ConceptPojo.builder ()
+                                    .randomID ()
+                                    .name (EToopConcept.FOUNDATION_DATE)
+                                    .valueDate (PDTFactory.createLocalDate (1960,
+                                            Month.AUGUST,
+                                            12))));
+  }
+
+  @Nonnull
   private static DatasetPojo.Builder _dataset ()
   {
     return DatasetPojo.builder ()
@@ -170,6 +196,13 @@ public final class EDMResponseTest
   public void createConceptResponse ()
   {
     final EDMResponse aResp = EDMResponse.reader ().read (ClassPathResource.getInputStream ("Concept Response.xml"));
+    _testWriteAndRead (aResp);
+  }
+
+  @Test
+  public void createConceptResponseDeprecatedAPI ()
+  {
+    final EDMResponse aResp = _respConceptDeprecated ().build();
     _testWriteAndRead (aResp);
   }
 

--- a/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
+++ b/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
@@ -15,32 +15,23 @@
  */
 package eu.toop.edm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.time.Month;
-import java.util.UUID;
-
-import javax.annotation.Nonnull;
-
-import eu.toop.edm.model.*;
-import eu.toop.edm.xml.cccev.CCCEV;
-import eu.toop.regrep.RegRep4Reader;
-import org.junit.Test;
-import org.w3c.dom.Document;
-
 import com.helger.commons.collection.impl.ICommonsList;
 import com.helger.commons.datetime.PDTFactory;
 import com.helger.commons.io.resource.ClassPathResource;
 import com.helger.commons.mock.CommonsTestHelper;
 import com.helger.schematron.svrl.AbstractSVRLMessage;
-
+import eu.toop.edm.model.*;
 import eu.toop.edm.pilot.gbm.EToopConcept;
 import eu.toop.edm.schematron.SchematronEDM2Validator;
 import eu.toop.regrep.ERegRepResponseStatus;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import javax.annotation.Nonnull;
+import java.time.Month;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
 
 /**
  * Test class for class {@link EDMResponse}.

--- a/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
+++ b/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 
 import javax.annotation.Nonnull;
 
+import eu.toop.edm.model.*;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
@@ -35,14 +36,6 @@ import com.helger.commons.io.resource.ClassPathResource;
 import com.helger.commons.mock.CommonsTestHelper;
 import com.helger.schematron.svrl.AbstractSVRLMessage;
 
-import eu.toop.edm.model.AddressPojo;
-import eu.toop.edm.model.AgentPojo;
-import eu.toop.edm.model.ConceptPojo;
-import eu.toop.edm.model.DatasetPojo;
-import eu.toop.edm.model.DocumentReferencePojo;
-import eu.toop.edm.model.EQueryDefinitionType;
-import eu.toop.edm.model.QualifiedRelationPojo;
-import eu.toop.edm.model.RepositoryItemRefPojo;
 import eu.toop.edm.pilot.gbm.EToopConcept;
 import eu.toop.edm.schematron.SchematronEDM2Validator;
 import eu.toop.regrep.ERegRepResponseStatus;
@@ -105,7 +98,8 @@ public final class EDMResponseTest
   private static EDMResponse.Builder _respConcept ()
   {
     return _resp ().queryDefinition (EQueryDefinitionType.CONCEPT)
-                   .concept (ConceptPojo.builder ()
+                       .responseObject(ResponseObjectPojo.builder()
+                            .concept(ConceptPojo.builder ()
                                         .id ("ConceptID-1")
                                         .name (EToopConcept.REGISTERED_ORGANIZATION)
                                         .addChild (ConceptPojo.builder ()
@@ -121,7 +115,7 @@ public final class EDMResponseTest
                                                               .name (EToopConcept.FOUNDATION_DATE)
                                                               .valueDate (PDTFactory.createLocalDate (1960,
                                                                                                       Month.AUGUST,
-                                                                                                      12))));
+                                                                                                      12)))));
   }
 
   @Nonnull
@@ -154,16 +148,22 @@ public final class EDMResponseTest
   private static EDMResponse.Builder _respDocument ()
   {
     return _resp ().queryDefinition (EQueryDefinitionType.DOCUMENT)
-                   .dataset (_dataset ())
-                   .repositoryItemRef (RepositoryItemRefPojo.builder ()
+                   .responseObject(ResponseObjectPojo.builder()
+                      .randomID()
+                      .dataset (_dataset ())
+                      .repositoryItemRef (RepositoryItemRefPojo.builder ()
                                                             .title ("Evidence.pdf")
-                                                            .link ("https://www.example.com/evidence.pdf"));
+                                                            .link ("https://www.example.com/evidence.pdf")));
   }
 
   @Nonnull
   private static EDMResponse.Builder _respDocumentRef ()
   {
-    return _resp ().queryDefinition (EQueryDefinitionType.OBJECTREF).dataset (_dataset ());
+    return _resp ().queryDefinition (EQueryDefinitionType.OBJECTREF)
+            .addResponseObject(ResponseObjectPojo.builder()
+                .randomID().dataset (_dataset ()))
+            .addResponseObject(ResponseObjectPojo.builder()
+                    .randomID().dataset (_dataset ()));
   }
 
   @Test
@@ -194,7 +194,7 @@ public final class EDMResponseTest
       // This attempts to create an EDMResponse with a dataset element but with
       // ConceptQuery set as the QueryDefinition
       // which is not permitted and fails
-      _respConcept ().dataset (_dataset ()).build ();
+      _respConcept ().responseObject(ResponseObjectPojo.builder().dataset (_dataset ())).build ();
       fail ();
     }
     catch (final IllegalStateException ex)

--- a/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
+++ b/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
@@ -56,11 +56,9 @@ public final class EDMResponseTest
     // Write
     final byte [] aBytes = aResp.getWriter ().getAsBytes ();
     assertNotNull (aBytes);
-    System.out.println(aResp.getWriter().getAsString());
 
     // Re-read
-//    final EDMResponse aResp2 = EDMResponse.reader ().read (aBytes);
-    final EDMResponse aResp2 = EDMResponse.create(RegRep4Reader.queryResponse(CCCEV.XSDS).read(aBytes));
+    final EDMResponse aResp2 = EDMResponse.reader ().read (aBytes);
     // Compare with original
     assertEquals (aResp, aResp2);
     CommonsTestHelper.testDefaultImplementationWithEqualContentObject (aResp, aResp2);

--- a/toop-regrep/src/main/java/eu/toop/regrep/RegRepHelper.java
+++ b/toop-regrep/src/main/java/eu/toop/regrep/RegRepHelper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018-2020 toop.eu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.toop.regrep;
 
 import java.util.UUID;


### PR DESCRIPTION
This adds a ResponseObjectPojo class representing the RegistryObject/ObjectRef elements in the QueryResponse. This is required to properly support multiple datasets. 
Changes: 
- New ResponseObjectPojo class
- Concepts, Dataset and RepositoryItemRef have been moved from the EDMResponse to the ResponseObjectPojo class
- EDMResponse now contains a list of ResponseObjectPojos 
- Added a "compatibility layer" for the old concept response API in the EDMResponse. The builder/get methods are behaving exactly the same but they are marked as deprecated. 